### PR TITLE
Automatic filter indicator & Firefox fix 

### DIFF
--- a/app.js
+++ b/app.js
@@ -122,7 +122,7 @@ function extractFilteredActors(params) {
   var regex = /[,"]?actors:(.*?)[,"]/g
 
   matches = []
-  while ((match = regex.exec(filter)) != null) {
+  while ((match = regex.exec(decodeURIComponent(filter))) != null) {
     matches.push(normalizeActor(match[1]));
   }
   return matches

--- a/index.html
+++ b/index.html
@@ -50,6 +50,7 @@
 
   <!-- TEMPLATES -->
   <script type="text/html" id="hit-template">
+    <div><div style="padding-bottom: 165%;"></div></div>
     <div class="hit" style="background-image: url({{image}})">
       <div class="hit-flags">
         {{#promoted}}<span class="hit-flag">Promoted</span>{{/promoted}}

--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
 
 
   <!-- SCRIPTS -->
-  <script src="//cdn.jsdelivr.net/jquery/2.1.4/jquery.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/jquery/2.1.4/jquery.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/instantsearch.js@2.0.2/dist/instantsearch.min.js"></script>
   <script src="app.js"></script>
   <!-- /SCRIPTS -->

--- a/style.css
+++ b/style.css
@@ -178,7 +178,7 @@ header {
   background-image:         linear-gradient(to bottom, rgba(0,0,0,0) 30%, rgba(0,0,0,.8));
 }
 .hit {
-  position: relative;
+  position: absolute;
   display: flex;
   flex-direction: column;
   background-position: center center;
@@ -186,6 +186,10 @@ header {
   justify-content: space-between;
   flex-grow: 1;
   flex-basis: 0;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
 }
 .ais-hits {
   display: flex;
@@ -193,7 +197,7 @@ header {
   flex-wrap: wrap;
 }
 .ais-hits--item {
-  display: flex;
+  position: relative;
   max-width: 12.5%;
   margin-bottom: 30px;
   flex-grow: 1;
@@ -211,11 +215,6 @@ header {
     max-width: 33.333%;
     flex-basis: 33.333%;
   }
-}
-.ais-hits--item:before {
-  display: inline-block;
-  padding-bottom: 165%;
-  content: '';
 }
 .hit-content {
   font-size: 11px;


### PR DESCRIPTION
**Problem 1**: Automatic filter indicator was not appearing below the search bar

**Solution 1**: url was not being decoded so regex wasn't matching correctly. [See here](https://github.com/algolia/demo-query-rules/compare/fixsuggests?expand=1#diff-0364f57fbff2fabbe941ed20c328ef1aR125)


**Problem 2**: Firefox not rendering content correctly:
![image_960](https://user-images.githubusercontent.com/606411/37094865-8fa76a84-2214-11e8-9bbe-df565c76b515.png)

**Solution 2**: This is due to an aspect ratio hack that was implemented. The problem was fixed with a hack that should work across all major browsers. [Check out this explanation on StackOverflow](https://stackoverflow.com/a/23754080)